### PR TITLE
Small but important update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,25 @@ android {
     }
 }
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+
+
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.1.0'
     compile 'net.steamcrafted:load-toast:1.0.6'
+    compile('de.keyboardsurfer.android.widget:crouton:1.8.5@aar') {
+        // exclusion is not necessary, but generally a good idea.
+        exclude group: 'com.google.android', module: 'support-v4'
+    }
 }

--- a/app/src/main/java/infrmr/newsapp/github/com/ifrmr/settings/SettingsFragment.java
+++ b/app/src/main/java/infrmr/newsapp/github/com/ifrmr/settings/SettingsFragment.java
@@ -48,10 +48,6 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         // The preference for news feed topic
         ListPreference feedPref = (ListPreference) getPreferenceManager().findPreference("topicPref");
         feedPref.setSummary(feedPref.getEntry());
-
-        // The preference for network download
-        ListPreference listPref = (ListPreference) getPreferenceManager().findPreference("listPref");
-        listPref.setSummary(listPref.getEntry());
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,8 +4,7 @@
     <string name="action_refresh">Refresh</string>
     <string name="page_title">The Verge Articles </string>
     <string name="updated">Last updated:</string>
-    <string name="lost_connection">Lost connection.</string>
-    <string name="wifi_connected">Wi-Fi reconnected.</string>
+    <string name="no_connection">No internet connection.</string>
     <string name="connection_error">Unable to load content. Check your network connection.</string>
     <string name="connection_timeout">Connection timeout. Check your network connection and try again.</string>
     <string name="xml_error">Error parsing XML.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -11,13 +11,13 @@
             android:entryValues="@array/listValuesTopic" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preference_category_network">
-        <!-- Choice of downloading only on wifi -->
+        <!-- Choice of downloading only on wifi
         <ListPreference
             android:title="Download Feed"
             android:summary="Network connectivity required to download the feed."
-            android:key="listPref"
+            android:key="connectivityPref"
             android:defaultValue="Any"
             android:entries="@array/listArrayNetwork"
-            android:entryValues="@array/listValuesNetwork" />
+            android:entryValues="@array/listValuesNetwork" />  -->
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
The connectivity preference wasn't updated in preferences.xml, so MainActivity.loadPage() logic assumed 'Wifi Only' and refused to refresh while using mobile data. After updating references, decided to remove the preference. I don't think it will be a useful option until we're updating the feed in the background. 

Also fixed missing string references, and replaced Toast's with Crouton's. (Here's the new Library: https://github.com/keyboardsurfer/Crouton)
